### PR TITLE
Fixed issue with derivedwords

### DIFF
--- a/src/backend/lib/checked_board_gen.py
+++ b/src/backend/lib/checked_board_gen.py
@@ -473,8 +473,7 @@ def create_board(mainword,words,maxheight=20,maxwidth=20,maxretries=1000):
 
         for loc,data in zip(locs,fill):
             word,displacement=data
-            for i in derivedwords(word):
-                words.remove(i)
+            words-=derivedwords(word)
             r,c,dir=loc
             if dir=='a':
                 grid.add_word(word,r,c-displacement,dir)


### PR DESCRIPTION
Stops an error if a derivedword wasn't actually in the wordlist

Changing derivedwords to look like
```
def derivedwords(word):
    return {word,word+'s'}|({word[:-1]} if word[-1]=='s' else set())
```
should now run without errors